### PR TITLE
Tenant switch for SAML fed SSO connection

### DIFF
--- a/src/shared/Select/index.lite.tsx
+++ b/src/shared/Select/index.lite.tsx
@@ -1,12 +1,14 @@
 import { For, Fragment, useStore } from '@builder.io/mitosis';
 import styles from './index.module.css';
 import Spacer from '../Spacer/index.lite';
+import cssClassAssembler from '../../sso/utils/cssClassAssembler';
 
 interface SelectProps {
   label: string;
   id?: string;
   name: string;
   options: Array<{ value: string; text: string }>;
+  classNames?: { select?: string; label?: string };
   disabled?: boolean;
   selectedValue: string;
   handleChange: (event: any) => void;
@@ -16,22 +18,26 @@ export default function Select(props: SelectProps) {
     get id() {
       return props.id ? props.id : props.label.replace(/ /g, '');
     },
-    get divCss() {
-      return styles.div + (props.disabled ? ` ${styles['div--disabled']}` : '');
+    get cssClass() {
+      return {
+        div: styles.div + (props.disabled ? ` ${styles['div--disabled']}` : ''),
+        select: cssClassAssembler(props.classNames?.select, styles.select),
+        label: cssClassAssembler(props.classNames?.label, styles.label),
+      };
     },
   });
 
   return (
     <Fragment>
-      <label htmlFor={state.id} class={styles.label}>
+      <label htmlFor={state.id} class={state.cssClass.label}>
         {props.label}
       </label>
       <Spacer y={2} />
-      <div class={state.divCss}>
+      <div class={state.cssClass.div}>
         <select
           id={state.id}
           name={props.name}
-          class={styles.select}
+          class={state.cssClass.select}
           disabled={props.disabled ?? false}
           value={props.selectedValue}
           onChange={(event) => props.handleChange(event)}>
@@ -43,7 +49,7 @@ export default function Select(props: SelectProps) {
             )}
           </For>
         </select>
-        <span class={styles.focus}></span>
+        <span></span>
       </div>
     </Fragment>
   );

--- a/src/shared/Select/index.module.css
+++ b/src/shared/Select/index.module.css
@@ -74,7 +74,7 @@
   display: none;
 }
 
-.select:focus-visible + .focus {
+.select:focus-visible + span {
   position: absolute;
   top: -1px;
   left: -1px;
@@ -82,8 +82,8 @@
   bottom: -1px;
   border: 2px solid var(--select-focus);
   border-radius: inherit;
-  outline: 2px solid var(--primary-color-700);
-  outline-offset: 2px;
+  outline: var(--ring-offset-width) solid var(--ring-offset-color);
+  outline-offset: var(--ring-offset);
 }
 
 .div::after,

--- a/src/sso/connections/CreateConnection/index.lite.tsx
+++ b/src/sso/connections/CreateConnection/index.lite.tsx
@@ -1,7 +1,7 @@
 import { useStore, Show } from '@builder.io/mitosis';
 import CreateOIDCConnection from './oidc/index.lite';
 import CreateSAMLConnection from './saml/index.lite';
-import type { CreateSSOConnectionProps } from '../types';
+import type { CreateConnectionProps, CreateSSOConnectionProps } from '../types';
 import RadioGroup from '../../../shared/RadioGroup/index.lite';
 import Radio from '../../../shared/Radio/index.lite';
 import Spacer from '../../../shared/Spacer/index.lite';
@@ -14,6 +14,9 @@ export default function CreateSSOConnection(props: CreateSSOConnectionProps) {
     },
     get connectionIsOIDC(): boolean {
       return state.newConnectionType === 'oidc';
+    },
+    get sanitizedDefaults(): CreateConnectionProps['defaults'] {
+      return { ...props.defaults, tenant: props.defaults?.tenants || props.defaults?.tenant };
     },
     handleNewConnectionTypeChange(event: Event) {
       state.newConnectionType = (event.target as HTMLInputElement).value;
@@ -50,7 +53,7 @@ export default function CreateSSOConnection(props: CreateSSOConnectionProps) {
           successCallback={props.successCallback}
           cancelCallback={props.cancelCallback}
           displayHeader={false}
-          defaults={props.defaults}
+          defaults={state.sanitizedDefaults}
         />
       </Show>
       <Show when={state.connectionIsOIDC}>
@@ -64,7 +67,7 @@ export default function CreateSSOConnection(props: CreateSSOConnectionProps) {
           successCallback={props.successCallback}
           cancelCallback={props.cancelCallback}
           displayHeader={false}
-          defaults={props.defaults}
+          defaults={state.sanitizedDefaults}
         />
       </Show>
     </div>

--- a/src/sso/connections/CreateConnection/oidc/index.module.css
+++ b/src/sso/connections/CreateConnection/oidc/index.module.css
@@ -17,3 +17,8 @@
   display: flex;
   gap: 0.5rem;
 }
+
+.selectContainer {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/sso/connections/CreateConnection/saml/index.module.css
+++ b/src/sso/connections/CreateConnection/saml/index.module.css
@@ -17,3 +17,8 @@
   display: flex;
   gap: 0.5rem;
 }
+
+.selectContainer {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/sso/connections/types.ts
+++ b/src/sso/connections/types.ts
@@ -54,7 +54,9 @@ export interface CreateConnectionProps {
   };
   /** Use this boolean to toggle the header display on/off. Useful when using the connection component standalone */
   displayHeader?: boolean;
-  defaults?: Partial<SSOConnection & Pick<SAMLSSOConnection, 'forceAuthn'>>;
+  defaults?: Partial<
+    Omit<SSOConnection, 'tenant'> & Pick<SAMLSSOConnection, 'forceAuthn'> & { tenant: string[] | string }
+  >;
 }
 
 export interface CreateSSOConnectionProps
@@ -71,6 +73,7 @@ export interface CreateSSOConnectionProps
     saml?: Array<keyof SSOConnection>;
     oidc?: Array<keyof SSOConnection>;
   };
+  defaults?: ConnectionsWrapperProp['defaults'];
 }
 
 type FormObjValues = string | boolean | string[] | undefined;

--- a/src/sso/connections/types.ts
+++ b/src/sso/connections/types.ts
@@ -45,6 +45,7 @@ export interface CreateConnectionProps {
     form?: string;
     container?: string;
     input?: string;
+    select?: string;
     textarea?: string;
     radioContainer?: string;
     label?: string;
@@ -299,6 +300,7 @@ export interface ConnectionsWrapperProp {
   classNames?: {
     button?: { ctoa?: string; destructive?: string };
     input?: string;
+    select?: string;
     textarea?: string;
     confirmationPrompt?: ConfirmationPromptProps['classNames'];
     secretInput?: string;


### PR DESCRIPTION
Adds support for selecting the tenant while creating an SSO connection under a SAML federation app.