### PR TITLE
Google DSync Tweaks

### DIFF
--- a/src/dsync/CreateDirectory/index.lite.tsx
+++ b/src/dsync/CreateDirectory/index.lite.tsx
@@ -35,10 +35,17 @@ export default function CreateDirectory(props: CreateDirectoryProps) {
     showDomain: false,
     isSaving: false,
     get providers() {
-      return Object.entries<string>(DirectorySyncProviders)?.map(([value, text]) => ({
-        value,
-        text,
-      }));
+      return Object.entries<string>(DirectorySyncProviders)
+        ?.map(([value, text]) => ({
+          value,
+          text,
+        }))
+        .filter(({ value }) => {
+          if (props.disableGoogleProvider) {
+            return value !== 'google';
+          }
+          return true;
+        });
     },
     setProvider(event: any) {
       const _val = event?.target?.value;

--- a/src/dsync/DirectoriesWrapper/index.lite.tsx
+++ b/src/dsync/DirectoriesWrapper/index.lite.tsx
@@ -26,6 +26,16 @@ export default function DirectoriesWrapper(props: DirectoriesWrapperProps) {
     get dsyncEnabled(): boolean {
       return state.directoriesAdded && state.directories.some((directory) => directory.deactivated === false);
     },
+    get googleSCIMAuthzURL(): string | undefined {
+      if (props.disableGoogleProvider) {
+        return undefined;
+      }
+      let _url = props.urls.googleSCIMAuthz!;
+      const [urlPath, qs] = _url.split('?');
+      const urlParams = new URLSearchParams(qs);
+      urlParams.set('directoryId', state.directoryToEdit.id);
+      return `${urlPath}?${urlParams}`;
+    },
     directoryToEdit: DEFAULT_VALUES.directoryToEdit,
     get directoryFetchURL(): string {
       let _url = props.urls.get;
@@ -109,6 +119,7 @@ export default function DirectoriesWrapper(props: DirectoriesWrapperProps) {
           urls={{
             patch: `${props.urls.patch}/${state.directoryToEdit.id}`,
             delete: `${props.urls.delete}/${state.directoryToEdit.id}`,
+            googleSCIMAuthz: state.googleSCIMAuthzURL,
             get: state.directoryFetchURL,
           }}
         />
@@ -130,6 +141,7 @@ export default function DirectoriesWrapper(props: DirectoriesWrapperProps) {
           }}
           tenant={props.tenant}
           product={props.product}
+          disableGoogleProvider={props.disableGoogleProvider}
         />
       </Show>
     </div>

--- a/src/dsync/DirectoriesWrapper/index.lite.tsx
+++ b/src/dsync/DirectoriesWrapper/index.lite.tsx
@@ -39,10 +39,13 @@ export default function DirectoriesWrapper(props: DirectoriesWrapperProps) {
     switchToCreateView() {
       state.view = 'CREATE';
     },
+    switchToEditView(directory: Directory) {
+      state.view = 'EDIT';
+      state.directoryToEdit = directory;
+    },
     handleActionClick(action: 'edit' | 'view', directory: any) {
       if (action === 'edit') {
-        state.view = 'EDIT';
-        state.directoryToEdit = directory;
+        state.switchToEditView(directory);
       } else {
         typeof props.componentProps?.directoryList?.handleActionClick === 'function' &&
           props.componentProps.directoryList.handleActionClick('view', directory);
@@ -60,7 +63,9 @@ export default function DirectoriesWrapper(props: DirectoriesWrapperProps) {
           connection,
         });
       }
-      if (operation !== 'COPY') {
+      if (operation === 'CREATE') {
+        state.switchToEditView(connection!);
+      } else if (operation !== 'COPY') {
         state.switchToListView();
       }
     },

--- a/src/dsync/DirectoriesWrapper/index.lite.tsx
+++ b/src/dsync/DirectoriesWrapper/index.lite.tsx
@@ -26,16 +26,6 @@ export default function DirectoriesWrapper(props: DirectoriesWrapperProps) {
     get dsyncEnabled(): boolean {
       return state.directoriesAdded && state.directories.some((directory) => directory.deactivated === false);
     },
-    get googleSCIMAuthzURL(): string | undefined {
-      if (props.disableGoogleProvider) {
-        return undefined;
-      }
-      let _url = props.urls.googleSCIMAuthz!;
-      const [urlPath, qs] = _url.split('?');
-      const urlParams = new URLSearchParams(qs);
-      urlParams.set('directoryId', state.directoryToEdit.id);
-      return `${urlPath}?${urlParams}`;
-    },
     directoryToEdit: DEFAULT_VALUES.directoryToEdit,
     get directoryFetchURL(): string {
       let _url = props.urls.get;
@@ -119,7 +109,6 @@ export default function DirectoriesWrapper(props: DirectoriesWrapperProps) {
           urls={{
             patch: `${props.urls.patch}/${state.directoryToEdit.id}`,
             delete: `${props.urls.delete}/${state.directoryToEdit.id}`,
-            googleSCIMAuthz: state.googleSCIMAuthzURL,
             get: state.directoryFetchURL,
           }}
         />
@@ -141,7 +130,6 @@ export default function DirectoriesWrapper(props: DirectoriesWrapperProps) {
           }}
           tenant={props.tenant}
           product={props.product}
-          disableGoogleProvider={props.disableGoogleProvider}
         />
       </Show>
     </div>

--- a/src/dsync/EditDirectory/index.lite.tsx
+++ b/src/dsync/EditDirectory/index.lite.tsx
@@ -108,6 +108,16 @@ export default function EditDirectory(props: EditDirectoryProps) {
     get directoryFetchUrl() {
       return props.urls.get;
     },
+    get googleSCIMAuthzURL(): string | undefined {
+      if (!state.directoryUpdated.google_authorizationUrl) {
+        return undefined;
+      }
+      let _url = state.directoryUpdated.google_authorizationUrl;
+      const [urlPath, qs] = _url.split('?');
+      const urlParams = new URLSearchParams(qs);
+      urlParams.set('directoryId', state.directoryToEdit.id);
+      return `${urlPath}?${urlParams}`;
+    },
   });
 
   onUpdate(() => {
@@ -200,10 +210,10 @@ export default function EditDirectory(props: EditDirectoryProps) {
           />
           <Spacer y={6} />
         </Show>
-        <Show when={state.directoryUpdated?.type === 'google' && props.urls.googleSCIMAuthz}>
+        <Show when={state.directoryUpdated?.type === 'google' && state.googleSCIMAuthzURL}>
           <InputWithCopyButton
             label='Google SCIM Authorization url'
-            text={props.urls.googleSCIMAuthz!}
+            text={state.googleSCIMAuthzURL}
             copyDoneCallback={props.successCallback}
             classNames={state.classes.inputField}
           />

--- a/src/dsync/EditDirectory/index.lite.tsx
+++ b/src/dsync/EditDirectory/index.lite.tsx
@@ -172,7 +172,7 @@ export default function EditDirectory(props: EditDirectoryProps) {
           />
           <Spacer y={6} />
         </Show>
-        <Show when={!state.isExcluded('scim_endpoint')}>
+        <Show when={!state.isExcluded('scim_endpoint') && state.directoryUpdated?.type !== 'google'}>
           <InputWithCopyButton
             label='SCIM Endpoint'
             text={state.directoryUpdated.scim?.endpoint}
@@ -181,7 +181,7 @@ export default function EditDirectory(props: EditDirectoryProps) {
           />
           <Spacer y={6} />
         </Show>
-        <Show when={!state.isExcluded('scim_token')}>
+        <Show when={!state.isExcluded('scim_token') && state.directoryUpdated?.type !== 'google'}>
           <InputWithCopyButton
             label='SCIM Token'
             text={state.directoryUpdated.scim?.secret}

--- a/src/dsync/EditDirectory/index.lite.tsx
+++ b/src/dsync/EditDirectory/index.lite.tsx
@@ -200,6 +200,18 @@ export default function EditDirectory(props: EditDirectoryProps) {
           />
           <Spacer y={6} />
         </Show>
+        <Show when={state.directoryUpdated?.type === 'google' && props.urls.googleSCIMAuthz}>
+          <InputWithCopyButton
+            label='Google SCIM Authorization url'
+            text={props.urls.googleSCIMAuthz!}
+            copyDoneCallback={props.successCallback}
+            classNames={state.classes.inputField}
+          />
+          <div id='scim-authz-hint' class={defaultClasses.hint}>
+            The URL that your tenant needs to authorize the application to access their Google Directory.
+          </div>
+          <Spacer y={6} />
+        </Show>
         <Show when={!state.isExcluded('webhook_url')}>
           <InputField
             type='url'

--- a/src/dsync/EditDirectory/index.lite.tsx
+++ b/src/dsync/EditDirectory/index.lite.tsx
@@ -115,7 +115,7 @@ export default function EditDirectory(props: EditDirectoryProps) {
       let _url = state.directoryUpdated.google_authorization_url;
       const [urlPath, qs] = _url.split('?');
       const urlParams = new URLSearchParams(qs);
-      urlParams.set('directoryId', state.directoryToEdit.id);
+      urlParams.set('directoryId', state.directoryUpdated.id);
       return `${urlPath}?${urlParams}`;
     },
   });

--- a/src/dsync/EditDirectory/index.lite.tsx
+++ b/src/dsync/EditDirectory/index.lite.tsx
@@ -109,10 +109,10 @@ export default function EditDirectory(props: EditDirectoryProps) {
       return props.urls.get;
     },
     get googleSCIMAuthzURL(): string | undefined {
-      if (!state.directoryUpdated.google_authorizationUrl) {
+      if (!state.directoryUpdated.google_authorization_url) {
         return undefined;
       }
-      let _url = state.directoryUpdated.google_authorizationUrl;
+      let _url = state.directoryUpdated.google_authorization_url;
       const [urlPath, qs] = _url.split('?');
       const urlParams = new URLSearchParams(qs);
       urlParams.set('directoryId', state.directoryToEdit.id);

--- a/src/dsync/EditDirectory/index.module.css
+++ b/src/dsync/EditDirectory/index.module.css
@@ -53,3 +53,8 @@
   display: flex;
   gap: 0.5rem;
 }
+
+.hint {
+  font-size: 0.75rem;
+  line-height: 2rem;
+}

--- a/src/dsync/types.ts
+++ b/src/dsync/types.ts
@@ -19,6 +19,7 @@ export interface CreateDirectoryProps {
   };
   /** Use this boolean to toggle the header display on/off. Useful when using the create component standalone */
   displayHeader?: boolean;
+  disableGoogleProvider?: boolean;
   tenant?: string;
   product?: string;
 }

--- a/src/dsync/types.ts
+++ b/src/dsync/types.ts
@@ -59,6 +59,7 @@ export interface EditDirectoryProps {
     patch: string;
     delete: string;
     get: string;
+    googleSCIMAuthz?: string;
   };
   errorCallback?: (errMessage: string) => void;
   successCallback?: (info: { operation: 'UPDATE' | 'DELETE' | 'COPY'; connection?: Directory }) => void;
@@ -114,10 +115,12 @@ export interface DirectoriesWrapperProps {
     post: string;
     patch: string;
     delete: string;
+    googleSCIMAuthz?: string;
   };
   title?: string;
   tenant?: string;
   product?: string;
+  disableGoogleProvider?: boolean;
 }
 
 export type ApiSuccess<T> = { data: T; pageToken?: string };

--- a/src/dsync/types.ts
+++ b/src/dsync/types.ts
@@ -59,7 +59,6 @@ export interface EditDirectoryProps {
     patch: string;
     delete: string;
     get: string;
-    googleSCIMAuthz?: string;
   };
   errorCallback?: (errMessage: string) => void;
   successCallback?: (info: { operation: 'UPDATE' | 'DELETE' | 'COPY'; connection?: Directory }) => void;
@@ -115,12 +114,10 @@ export interface DirectoriesWrapperProps {
     post: string;
     patch: string;
     delete: string;
-    googleSCIMAuthz?: string;
   };
   title?: string;
   tenant?: string;
   product?: string;
-  disableGoogleProvider?: boolean;
 }
 
 export type ApiSuccess<T> = { data: T; pageToken?: string };


### PR DESCRIPTION
- Display SCIM endpoint/token only for providers other than Google.
- Ability to disable Google provider.
- Use the Google SCIM Authorization endpoint in directory response (included in https://github.com/boxyhq/jackson/pull/2421) to display in the Edit directory view.